### PR TITLE
Add 0.5em outer margin to fullwidth environment

### DIFF
--- a/didactic.dtx
+++ b/didactic.dtx
@@ -1467,7 +1467,9 @@ def didactic_run_code(code, /, **kwargs):
 % To do this we first add a |fullwidth| environment\footnote{%
 %   Similarly to \url{https://tex.stackexchange.com/a/350944/17418}.
 % }.
-% We can get the |adjustwidth| environment from the |changepage| package 
+% The environment expands into the margin on both sides, but leaves 0.5em of
+% outer margin for aesthetic spacing.
+% We can get the |adjustwidth| environment from the |changepage| package
 % whenever |memoir| isn't used\footnote{%
 %   The |memoir| class uses |changepage|, that's the origin of the package.
 % }.
@@ -1476,20 +1478,20 @@ def didactic_run_code(code, /, **kwargs):
 \RequirePackage{calc}
 \newlength{\@didactic@textbytext@oldcolumnwidth}
 \NewDocumentEnvironment{fullwidth}{}{%
-  \setlength{\columnwidth}{\textwidth+2em+\marginparwidth+\marginparsep}
+  \setlength{\columnwidth}{\textwidth+1.5em+\marginparwidth+\marginparsep}
   \if@twoside
     \IfStrEqCase{\@didactic@marginparmargin}{%
-        {inner}{\begin{adjustwidth*}{-\marginparwidth-\marginparsep}{-2em}}
-        {left}{\begin{adjustwidth}{-\marginparwidth-\marginparsep}{-2em}}
-        {outer}{\begin{adjustwidth*}{-2em}{-\marginparwidth-\marginparsep}}
-        {right}{\begin{adjustwidth}{-2em}{-\marginparwidth-\marginparsep}}
+        {inner}{\begin{adjustwidth*}{-\marginparwidth-\marginparsep}{-1.5em}}
+        {left}{\begin{adjustwidth}{-\marginparwidth-\marginparsep}{-1.5em}}
+        {outer}{\begin{adjustwidth*}{-1.5em}{-\marginparwidth-\marginparsep}}
+        {right}{\begin{adjustwidth}{-1.5em}{-\marginparwidth-\marginparsep}}
       }[\relax]
   \else
     \IfStrEqCase{\@didactic@marginparmargin}{%
-        {inner}{\begin{adjustwidth}{-\marginparwidth-\marginparsep}{-2em}}
-        {left}{\begin{adjustwidth}{-\marginparwidth-\marginparsep}{-2em}}
-        {outer}{\begin{adjustwidth}{-2em}{-\marginparwidth-\marginparsep}}
-        {right}{\begin{adjustwidth}{-2em}{-\marginparwidth-\marginparsep}}
+        {inner}{\begin{adjustwidth}{-\marginparwidth-\marginparsep}{-1.5em}}
+        {left}{\begin{adjustwidth}{-\marginparwidth-\marginparsep}{-1.5em}}
+        {outer}{\begin{adjustwidth}{-1.5em}{-\marginparwidth-\marginparsep}}
+        {right}{\begin{adjustwidth}{-1.5em}{-\marginparwidth-\marginparsep}}
       }[\relax]
   \fi
 }{


### PR DESCRIPTION
Changes fullwidth environment from extending all the way to page edge
to leaving 0.5em of outer margin for aesthetic spacing. Updates both
implementation (2em → 1.5em) and documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

This doesn't seem to work.
