### PR TITLE
Reuse footnote citations on the same page (and across twoside spreads)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ didactic.sty
 ltxobj
 test.pdf
 test.unq
+test-footcite.pdf
+test-footcite.unq
+test-footcite-twoside.pdf
+test-footcite-twoside.unq
 didactic.tar.gz
 didactic.unq
 didactic.hd

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ LATEXFLAGS=-shell-escape
 PYTHONTEX=python3 $(shell which pythontex) --interpreter python:python3
 
 .PHONY: all
-all: didactic.sty didactic.pdf didactic.tar.gz test.pdf
+all: didactic.sty didactic.pdf didactic.tar.gz test.pdf test-footcite.pdf \
+	test-footcite-twoside.pdf
 
 SRC+=	didactic.dtx hello.py idea.tex lightblock.tex ProvideSemanticEnv.tex
 
@@ -21,6 +22,21 @@ didactic.tar.gz: ${SRC} didactic.ins LICENSE Makefile README.md didactic.pdf
 	tar -czf $@ --transform "s|^|didactic/|" $^
 
 test.pdf: test.tex didactic.sty
+	${PDFLATEX} ${LATEXFLAGS} $<
+
+# footnote-reuse test: needs biber and two more passes so zref abspage labels
+# resolve from the .aux.
+test-footcite.pdf: test-footcite.tex test-footcite.bib didactic.sty
+	${PDFLATEX} ${LATEXFLAGS} $<
+	biber test-footcite
+	${PDFLATEX} ${LATEXFLAGS} $<
+	${PDFLATEX} ${LATEXFLAGS} $<
+
+# same as above but exercises cross-spread reuse under twoside.
+test-footcite-twoside.pdf: test-footcite-twoside.tex test-footcite.bib didactic.sty
+	${PDFLATEX} ${LATEXFLAGS} $<
+	biber test-footcite-twoside
+	${PDFLATEX} ${LATEXFLAGS} $<
 	${PDFLATEX} ${LATEXFLAGS} $<
 
 VERSION=$(shell sed -En "s/^.*v([0-9]+\.[0-9]+) didactic.*$$/\1/p" didactic.dtx)

--- a/didactic.dtx
+++ b/didactic.dtx
@@ -613,6 +613,91 @@
 \nouppercaseheads
 %    \end{macrocode}
 %
+% Now we want to ensure that we reuse the footnotes for references on the same 
+% page.
+% The idea is that we keep track of the page number for every reference (and 
+% footnote).
+% Then we can check if the page number has changed or not.
+% If it has changed, we do everything new.
+% Otherwise we reuse the same footnote mark.
+%    \begin{macrocode}
+% adapted from https://tex.stackexchange.com/a/408064/17418
+% and https://tex.stackexchange.com/a/315805/17418
+\usepackage{ifoddpage}
+\makeatletter
+\def\@defkeyasused#1{%
+  \typeout{defkeyasused set \thekey{} to page \arabic{page} note \thefootnote}%
+  \expandafter\xdef\csname repeatcite@#1\endcsname{\thefootnote}%
+  \expandafter\xdef\csname citepage@#1\endcsname{\arabic{page}}%
+}%
+\def\@resetkey#1{%
+  \typeout{resetkey reset #1:
+    \arabic{page}
+    and \oddpage@page{}
+    and \csname citepage@#1\endcsname}%
+  \global\expandafter\let\csname repeatcite@#1\endcsname=\relax%
+}
+\def\@resetkeyifnewpage#1{%
+  \@ifundefined{citepage@#1}
+    {\ifciteseen
+      {\@resetkey{#1}}
+      {\relax}}%
+    {\expandafter\ifnum\csname citepage@#1\endcsname<\oddpage@page\relax
+      \@resetkey{#1}%
+     \fi}%
+}
+\def\footnoteormark#1{%
+  \edef\thekey{\thefield{entrykey}}%
+  \typeout{footnoteormark \thekey}%
+  \@resetkeyifnewpage{\thekey}%
+  \@ifundefined{repeatcite@\thekey}%
+    {\mkbibfootnote{#1}\@defkeyasused{\thekey}}%
+    {\footnotemark[\csname repeatcite@\thekey\endcsname]%
+      \typeout{footnoteormark reused \thekey}}%
+}
+\def\ifnonotes#1#2{%
+  \ifboolexpr{test {\iffieldundef{prenote}} and test {\iffieldundef{postnote}}}
+    {#1}
+    {#2}%
+}
+\def\noisymkbibfootnote#1{%
+  \typeout{noisymkbibfootnote}%
+  \mkbibfootnote{#1}%
+}
+\let\@mkbibfootnoteifnotes=\noisymkbibfootnote
+\NewDocumentCommand\mkbibfootnoteifnotes{m}{%
+  \typeout{mkbibfootnoteifnotes \meaning\@mkbibfootnoteifnotes}%
+  \@mkbibfootnoteifnotes{#1}%
+}
+%\DeclareCiteCommand{\footcite}%
+%  [\expandafter\mkbibfootnoteifnotes]
+%  {\ifnonotes
+%    {\global\let\@mkbibfootnoteifnotes=\relax\typeout{set relax}}
+%    {\global\let\@mkbibfootnoteifnotes=\noisymkbibfootnote\typeout{set footnote}}%
+%   \usebibmacro{prenote}}
+%  {\usebibmacro{citeindex}%
+%   \typeout{footcite \thefield{entrykey}}%
+%   \ifnonotes
+%    {\footnoteormark{\usebibmacro{cite}}}
+%    {\usebibmacro{cite}}}
+%  {\ifnonotes
+%    {\textsuperscript{,}}
+%    {\multicitedelim}}
+%  {\usebibmacro{postnote}}
+\DeclareCiteCommand{\footcite}%
+  [\unspace]
+  {\relax}
+  {\usebibmacro{citeindex}%
+    \typeout{footcite \thefield{entrykey}}%
+    \ifnonotes{\footnoteormark}{\mkbibfootnote}
+      {\usebibmacro{prenote}\usebibmacro{cite}\usebibmacro{postnote}}}
+  {\textsuperscript{,}}
+  {\relax}
+\makeatother
+\DeclareMultiCiteCommand{\footcites}{\footcite}{\textsuperscript{,}}
+\DeclareAutoCiteCommand{footnote}[f]{\footcite}{\footcites}
+%    \end{macrocode}
+%
 % And that concludes the |memoir| part.
 %    \begin{macrocode}
 \fi% end \if@didactic@memoir

--- a/didactic.dtx
+++ b/didactic.dtx
@@ -613,7 +613,35 @@
 \nouppercaseheads
 %    \end{macrocode}
 %
-% Now we want to ensure that we reuse the footnotes for references on the same 
+% And that concludes the |memoir| part.
+%    \begin{macrocode}
+\fi% end \if@didactic@memoir
+%    \end{macrocode}
+%
+% We also want to adapt the citation commands of a few packages to use 
+% footnotes.
+% For these, we check if the package is loaded, if it is, we do the changes.
+% We don't load the packages ourselves, we assume the user has done that.
+% This also means that the |didactic| package should be loaded last.
+%    \begin{macrocode}
+\@ifpackageloaded{biblatex}{%
+  \ExecuteBibliographyOptions{%
+    autocite=footnote,
+    singletitle=false,
+    maxbibnames=99,
+    isbn=false,doi=false,url=false
+  }
+  % from https://tex.stackexchange.com/a/374059/17418
+  \DeclareCiteCommand{\fullauthorcite}
+    {\usebibmacro{prenote}}
+    {\usedriver
+      {\setcounter{maxnames}{99}% use up to 99 authors
+        \DeclareNameAlias{sortname}{default}}
+      {\thefield{entrytype}}}
+    {\multicitedelim}
+    {\usebibmacro{postnote}}
+%    \end{macrocode}
+% Now we want to ensure that we reuse the footnotes for references on the same
 % page.
 % The idea is that we keep track of the page number for every reference (and 
 % footnote).
@@ -621,10 +649,7 @@
 % If it has changed, we do everything new.
 % Otherwise we reuse the same footnote mark.
 %    \begin{macrocode}
-% adapted from https://tex.stackexchange.com/a/408064/17418
-% and https://tex.stackexchange.com/a/315805/17418
-\usepackage{ifoddpage}
-\makeatletter
+\RequirePackage{ifoddpage}
 \def\@defkeyasused#1{%
   \typeout{defkeyasused set \thekey{} to page \arabic{page} note \thefootnote}%
   \expandafter\xdef\csname repeatcite@#1\endcsname{\thefootnote}%
@@ -660,30 +685,6 @@
     {#1}
     {#2}%
 }
-\def\noisymkbibfootnote#1{%
-  \typeout{noisymkbibfootnote}%
-  \mkbibfootnote{#1}%
-}
-\let\@mkbibfootnoteifnotes=\noisymkbibfootnote
-\NewDocumentCommand\mkbibfootnoteifnotes{m}{%
-  \typeout{mkbibfootnoteifnotes \meaning\@mkbibfootnoteifnotes}%
-  \@mkbibfootnoteifnotes{#1}%
-}
-%\DeclareCiteCommand{\footcite}%
-%  [\expandafter\mkbibfootnoteifnotes]
-%  {\ifnonotes
-%    {\global\let\@mkbibfootnoteifnotes=\relax\typeout{set relax}}
-%    {\global\let\@mkbibfootnoteifnotes=\noisymkbibfootnote\typeout{set footnote}}%
-%   \usebibmacro{prenote}}
-%  {\usebibmacro{citeindex}%
-%   \typeout{footcite \thefield{entrykey}}%
-%   \ifnonotes
-%    {\footnoteormark{\usebibmacro{cite}}}
-%    {\usebibmacro{cite}}}
-%  {\ifnonotes
-%    {\textsuperscript{,}}
-%    {\multicitedelim}}
-%  {\usebibmacro{postnote}}
 \DeclareCiteCommand{\footcite}%
   [\unspace]
   {\relax}
@@ -693,38 +694,12 @@
       {\usebibmacro{prenote}\usebibmacro{cite}\usebibmacro{postnote}}}
   {\textsuperscript{,}}
   {\relax}
-\makeatother
 \DeclareMultiCiteCommand{\footcites}{\footcite}{\textsuperscript{,}}
 \DeclareAutoCiteCommand{footnote}[f]{\footcite}{\footcites}
 %    \end{macrocode}
+% And that concludes the code for reusing footnotes for references.
 %
-% And that concludes the |memoir| part.
 %    \begin{macrocode}
-\fi% end \if@didactic@memoir
-%    \end{macrocode}
-%
-% We also want to adapt the citation commands of a few packages to use 
-% footnotes.
-% For these, we check if the package is loaded, if it is, we do the changes.
-% We don't load the packages ourselves, we assume the user has done that.
-% This also means that the |didactic| package should be loaded last.
-%    \begin{macrocode}
-\@ifpackageloaded{biblatex}{%
-  \ExecuteBibliographyOptions{%
-    autocite=footnote,
-    singletitle=false,
-    maxbibnames=99,
-    isbn=false,doi=false,url=false
-  }
-  % from https://tex.stackexchange.com/a/374059/17418
-  \DeclareCiteCommand{\fullauthorcite}
-    {\usebibmacro{prenote}}
-    {\usedriver
-      {\setcounter{maxnames}{99}% use up to 99 authors
-        \DeclareNameAlias{sortname}{default}}
-      {\thefield{entrytype}}}
-    {\multicitedelim}
-    {\usebibmacro{postnote}}
 }{}
 \@ifpackageloaded{csquotes}{%
   \SetCiteCommand{\autocite}

--- a/didactic.dtx
+++ b/didactic.dtx
@@ -557,14 +557,21 @@
 \footnotesinmargin
 
 \RequirePackage{ragged2e}
-\renewcommand{\sidefootform}{\RaggedRight}
-\renewcommand{\foottextfont}{\footnotesize\RaggedRight}
-
 \setmpjustification{\RaggedRight}{\RaggedRight}
-
-% margin figure and caption typeset ragged against text block
+% margin figure and caption typeset ragged against text block.
+% from the memman page 175.
 \setfloatadjustment{marginfigure}{\mpjustification}
 \setmarginfloatcaptionadjustment{figure}{\captionstyle{\mpjustification}}
+
+\renewcommand{\sidefootform}{\mpjustification}
+\fi % we want this to exist even when not using memoir,
+    % then we can reuse it later.
+% to use renewcommand if the command doesn't exist
+\RequirePackage{ragged2e}
+\providecommand{\foottextfont}{\relax}
+\renewcommand{\foottextfont}{\footnotesize\RaggedRight}
+\if@didactic@memoir
+\renewcommand{\foottextfont}{\footnotesize\mpjustification}
 
 % side captions
 % https://tex.stackexchange.com/a/275626/17418
@@ -572,9 +579,7 @@
 \setsidecappos{t}
 \checkandfixthelayout
 \setsidecaps{\marginparsep}{\marginparwidth}
-\renewcommand{\sidecapstyle}{%
-  \captionstyle{\RaggedRight}
-}
+\renewcommand{\sidecapstyle}{\mpjustification}
 
 \makechapterstyle{arthangnum}{%
   \typeout{Using arthangnum chapter style.}
@@ -1124,8 +1129,9 @@
 \NewDocumentCommand{\indentedmarginpar}{+m}{%
   \@ifclassloaded{memoir}{\strictpagecheck}{\relax}%
   \marginpar{%
-    \setlength{\parindent}{1.0em}\footnotesize
-    \@afterindentfalse\@afterheading #1
+    \foottextfont%
+    \setlength{\parindent}{2em}%
+    \@afterindentfalse\@afterheading #1%
   }%
 }
 %    \end{macrocode}

--- a/didactic.dtx
+++ b/didactic.dtx
@@ -669,56 +669,88 @@
     {\multicitedelim}
     {\usebibmacro{postnote}}
 %    \end{macrocode}
-% Now we want to ensure that we reuse the footnotes for references on the same
-% page.
-% The idea is that we keep track of the page number for every reference (and 
-% footnote).
-% Then we can check if the page number has changed or not.
-% If it has changed, we do everything new.
-% Otherwise we reuse the same footnote mark.
+% Now we want to reuse footnotes for citations that repeat on the same page: a
+% second \cs{footcite} of the same reference on the same page should reuse the
+% first footnote's number (a bare \cs{footnotemark}) instead of emitting a new
+% footnote, while a citation on a fresh page gets a fresh footnote.
+%
+% The hard part is knowing \emph{which} page we are on. The page counter
+% (\cs{c@page}) is asynchronous --- it is only authoritative inside the output
+% routine --- so testing it at the point of the citation misfires near page
+% breaks. We instead take the absolute page number from the |.aux| file via
+% |zref|'s |abspage| property. That value is written by the previous run, so it
+% is one compilation behind and settles on the second pass; but, unlike
+% \cs{c@page}, it is reliable.
+%
+% For every \cs{footcite} we drop a uniquely named |zref| label at the point of
+% citation. A citation's \emph{reuse identity} is its entry key together with its
+% pre- and postnote, so |\footcite[see][p.~5]{A}| reuses a matching earlier one
+% while |\footcite[cf.][p.~7]{A}| gets its own footnote; with no notes this
+% reduces to the bare key. For each identity we remember the footnote number and
+% the label of the last real footnote, and a later citation of that identity
+% reuses the number iff that footnote lies in the same \emph{reuse group}.
+%
+% The reuse group is normally just the page (|abspage|). Under |twoside|, though,
+% the two pages of an open spread --- a verso (even |abspage|) on the left and
+% the recto (odd |abspage|) on its right --- are read together, so a footnote on
+% the verso may be reused on the recto. We therefore group the pages of a spread,
+% \{2,3\}, \{4,5\}, \dots\ (page~1 sits alone), by mapping an odd |abspage| down
+% to the even page it faces. The recto/verso parity is simply the parity of
+% |abspage| (odd = recto), so we need no |ifoddpage|; we only test \cs{if@twoside}
+% to decide whether to group at all. (We deliberately avoid \cs{numexpr} division
+% for this: it \emph{rounds}, so 3/2 would give~2 and split the \{2,3\} spread.)
 %    \begin{macrocode}
-\RequirePackage{ifoddpage}
-\def\@defkeyasused#1{%
-  \typeout{defkeyasused set \thekey{} to page \arabic{page} note \thefootnote}%
-  \expandafter\xdef\csname repeatcite@#1\endcsname{\thefootnote}%
-  \expandafter\xdef\csname citepage@#1\endcsname{\arabic{page}}%
-}%
-\def\@resetkey#1{%
-  \typeout{resetkey reset #1:
-    \arabic{page}
-    and \oddpage@page{}
-    and \csname citepage@#1\endcsname}%
-  \global\expandafter\let\csname repeatcite@#1\endcsname=\relax%
+\RequirePackage{zref-abspage,zref-user}
+\newcount\@didactic@fncount  % serial number for unique reuse labels
+\newcount\@didactic@fnpa     % abspage of the previous footnote
+\newcount\@didactic@fnpb     % abspage of the current citation
+\newcount\@didactic@fnga     % reuse group of the previous footnote
+\newcount\@didactic@fngb     % reuse group of the current citation
+\newif\if@didactic@fnreuse
+% \@didactic@fnabspage{<label>}: the abspage of a zref label, 0 if unresolved
+\newcommand\@didactic@fnabspage[1]{\zref@extractdefault{#1}{abspage}{0}}
+% \@didactic@fntogroup<count>: collapse the page in <count> to its reuse group ---
+% the page itself, or, under twoside, the verso page of its open spread (an odd
+% abspage mapped down to the even page it faces).
+\def\@didactic@fntogroup#1{\if@twoside\ifodd#1 \advance#1\m@ne \fi\fi}
+\def\@didactic@fnnewnote#1{%
+  \mkbibfootnote{#1}%
+  \expandafter\xdef\csname @didactic@fncite@\@didactic@fnkey\endcsname
+    {\the\c@footnote}%
+  \expandafter\xdef\csname @didactic@fnlabel@\@didactic@fnkey\endcsname
+    {\@didactic@fnhere}%
 }
-\def\@resetkeyifnewpage#1{%
-  \@ifundefined{citepage@#1}
-    {\ifciteseen
-      {\@resetkey{#1}}
-      {\relax}}%
-    {\expandafter\ifnum\csname citepage@#1\endcsname<\oddpage@page\relax
-      \@resetkey{#1}%
+\def\@didactic@footnoteormark#1{%
+  % reuse identity: entry key + prenote + postnote, detokenized for csname safety
+  \protected@edef\@didactic@fnkey{%
+    \thefield{entrykey}@\thefield{prenote}@\thefield{postnote}}%
+  \edef\@didactic@fnkey{\detokenize\expandafter{\@didactic@fnkey}}%
+  \global\advance\@didactic@fncount\@ne
+  \edef\@didactic@fnhere{didacticfn@\the\@didactic@fncount}%
+  \expandafter\zlabel\expandafter{\@didactic@fnhere}%
+  \ifcsundef{@didactic@fncite@\@didactic@fnkey}%
+    {\@didactic@fnnewnote{#1}}%
+    {\edef\@didactic@fnprev{\csname @didactic@fnlabel@\@didactic@fnkey\endcsname}%
+     \@didactic@fnpa=\@didactic@fnabspage{\@didactic@fnprev}\relax
+     \@didactic@fnpb=\@didactic@fnabspage{\@didactic@fnhere}\relax
+     \@didactic@fnga=\@didactic@fnpa \@didactic@fntogroup\@didactic@fnga
+     \@didactic@fngb=\@didactic@fnpb \@didactic@fntogroup\@didactic@fngb
+     % reuse only when both pages are resolved (>0) and share a group
+     \@didactic@fnreusetrue
+     \ifnum\@didactic@fnpa<\@ne \@didactic@fnreusefalse\fi
+     \ifnum\@didactic@fnpb<\@ne \@didactic@fnreusefalse\fi
+     \ifnum\@didactic@fnga=\@didactic@fngb \else \@didactic@fnreusefalse\fi
+     \if@didactic@fnreuse
+       \footnotemark[\csname @didactic@fncite@\@didactic@fnkey\endcsname]%
+     \else
+       \@didactic@fnnewnote{#1}%
      \fi}%
-}
-\def\footnoteormark#1{%
-  \edef\thekey{\thefield{entrykey}}%
-  \typeout{footnoteormark \thekey}%
-  \@resetkeyifnewpage{\thekey}%
-  \@ifundefined{repeatcite@\thekey}%
-    {\mkbibfootnote{#1}\@defkeyasused{\thekey}}%
-    {\footnotemark[\csname repeatcite@\thekey\endcsname]%
-      \typeout{footnoteormark reused \thekey}}%
-}
-\def\ifnonotes#1#2{%
-  \ifboolexpr{test {\iffieldundef{prenote}} and test {\iffieldundef{postnote}}}
-    {#1}
-    {#2}%
 }
 \DeclareCiteCommand{\footcite}%
   [\unspace]
   {\relax}
   {\usebibmacro{citeindex}%
-    \typeout{footcite \thefield{entrykey}}%
-    \ifnonotes{\footnoteormark}{\mkbibfootnote}
+    \@didactic@footnoteormark
       {\usebibmacro{prenote}\usebibmacro{cite}\usebibmacro{postnote}}}
   {\textsuperscript{,}}
   {\relax}

--- a/test-footcite-twoside.tex
+++ b/test-footcite-twoside.tex
@@ -1,0 +1,34 @@
+% Test for footnote reuse ACROSS A SPREAD under twoside (didactic).
+%
+% Build TWICE so zref abspage labels resolve from the .aux:
+%   xelatex -pdf -shell-escape test-footcite-twoside && biber test-footcite-twoside \
+%     && xelatex -pdf -shell-escape test-footcite-twoside \
+%     && xelatex -pdf -shell-escape test-footcite-twoside
+%
+% Layout: page 1 recto (alone), spread {2,3}, spread {4,5}, ...
+% Expected in the resulting PDF:
+%   Page 2 (verso) \footcite{A}  -> footnote number N
+%   Page 3 (recto) \footcite{A}  -> REUSE N (same spread {2,3}, mark only)
+%   Page 4 (verso) \footcite{A}  -> FRESH number (new spread {4,5})
+\documentclass[twoside]{article}
+
+\usepackage[backend=biber,autocite=footnote,citestyle=verbose,style=verbose]{biblatex}
+\usepackage{csquotes}
+\usepackage{didactic}
+\addbibresource{test-footcite.bib}
+
+\begin{document}
+
+Page~1 (recto), intentionally left without citations.
+
+\newpage
+Page~2 (verso): first citation of the spread \footcite{A}.
+
+\newpage
+Page~3 (recto): same spread as page~2, so this \footcite{A} should reuse the
+footnote from page~2.
+
+\newpage
+Page~4 (verso): a new spread, so this \footcite{A} must be a fresh footnote.
+
+\end{document}

--- a/test-footcite.bib
+++ b/test-footcite.bib
@@ -1,0 +1,13 @@
+@book{A,
+  author = {Anderson, Alice},
+  title  = {A Book About A},
+  year   = {2001},
+  publisher = {A Press},
+}
+
+@book{B,
+  author = {Bernard, Bob},
+  title  = {B Book About B},
+  year   = {2002},
+  publisher = {B Press},
+}

--- a/test-footcite.tex
+++ b/test-footcite.tex
@@ -1,0 +1,33 @@
+% Test for same-page footnote reuse in \footcite (didactic).
+%
+% Build TWICE so zref abspage labels resolve from the .aux:
+%   xelatex -pdf -shell-escape test-footcite && biber test-footcite \
+%     && xelatex -pdf -shell-escape test-footcite \
+%     && xelatex -pdf -shell-escape test-footcite
+%
+% Expected in the resulting PDF:
+%   Page 1: the two \footcite{A} share ONE footnote number; \footcite{B} a
+%           different one. The annotated \footcite[see][p.~5]{A} pair shares one
+%           (new) number, and \footcite[cf.][p.~7]{A} gets yet another.
+%   Page 2: \footcite{A} produces a FRESH footnote number (new page).
+\documentclass{article}
+
+\usepackage[backend=biber,autocite=footnote,citestyle=verbose,style=verbose]{biblatex}
+\usepackage{csquotes}
+\usepackage{didactic}
+\addbibresource{test-footcite.bib}
+
+\begin{document}
+
+Same page, same key: first \footcite{A} and then again \footcite{A} should share
+one footnote. A different key \footcite{B} gets its own. Now annotated cites:
+\footcite[see][p.~5]{A} and once more \footcite[see][p.~5]{A} should share a
+footnote (identical notes), whereas \footcite[cf.][p.~7]{A} differs and gets a
+separate footnote.
+
+\newpage
+
+New page: \footcite{A} here must be a fresh footnote, not a reuse of the one on
+page~1.
+
+\end{document}


### PR DESCRIPTION
## What

Rewrites the same-page footnote-citation reuse so a repeated `\footcite` of the same reference reuses the first footnote's number (a bare `\footnotemark`) instead of emitting a duplicate footnote.

## Why

The old implementation compared the live page counter (through `ifoddpage`'s `\oddpage@page`, which was never primed with `\checkoddpage` and so degraded to the asynchronous `\c@page`). That misfires near page breaks and can point a reused mark at the wrong page. This code originated in the thesis repo, where it was ultimately abandoned (commented out); no clone had a working version.

## How

- Resolve the page from the `.aux` file via `zref`'s `abspage` property — reliable, one compilation behind, settles on the second pass.
- **Reuse identity** = entry key + prenote + postnote, so matching annotated cites reuse while differing notes get their own footnote (replaces the old `\ifnonotes` gate that excluded all annotated cites).
- **`twoside`**: reuse spans an open spread (verso+recto), since both pages are read together; **`oneside`**: per page. Recto/verso parity comes from `abspage`, so `ifoddpage` is dropped.
- Internals moved into the `@didactic@` namespace.

## Tests

Adds `test-footcite.tex` and `test-footcite-twoside.tex` (wired into the `Makefile`) covering same-page, same/different-note, new-page, and cross-spread reuse. Both build cleanly and the consuming paper builds and converges (0 rerun warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)