### PR TITLE
Load T1 fontenc with beramono under pdfLaTeX

### DIFF
--- a/didactic.dtx
+++ b/didactic.dtx
@@ -618,6 +618,9 @@
   % https://tex.stackexchange.com/a/506776/17418
   \usepackage{newpxtext,newpxmath}
 \else
+  % Bera Mono (below) exists only in T1 encoding; without it LaTeX
+  % silently substitutes Computer Modern Roman for \ttfamily.
+  \RequirePackage[T1]{fontenc}
   % https://tex.stackexchange.com/a/324757/17418
   % Palatino for main text and math
   \RequirePackage[osf,sc]{mathpazo}


### PR DESCRIPTION
## Summary
- The pdfLaTeX font branch selects Bera Mono, which only exists in T1/TS1 encodings, but did not load `fontenc`. A document that did not load `[T1]{fontenc}` itself got `Font shape OT1/fvm/m/n undefined` and LaTeX silently substituted Computer Modern Roman for `\ttfamily`, so code was typeset in a proportional font.
- Load `\RequirePackage[T1]{fontenc}` alongside `beramono`.

## Test plan
- [x] Regenerated `didactic.sty` from the `.dtx`
- [x] Rebuilt the learnlog literate PDF (memoir + minted): no `OT1/fvm` substitutions in the log, `pdffonts` shows BeraSansMono embedded, code pages render in monospace

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yUsxVnAp1GNSqn2okGsn5